### PR TITLE
Lisää journal.fi-ohjeisiin CSS-tyylitiedostojen käyttö

### DIFF
--- a/docs/_assets/StyleSheet.css
+++ b/docs/_assets/StyleSheet.css
@@ -1,0 +1,41 @@
+/* Tämä on div, johon HTML-lisäosa laittaa tekstin sisällön */
+#htmlContainer {
+	margin-top: 5%;
+	margin-bottom: 5%;
+	margin-left: auto;
+	margin-right: auto;
+	width: 90%;
+	max-width: 35em;
+}
+
+h1, h2, h3 {
+	line-height: 1.3em;
+}
+
+figure {
+	width: 100%;
+	display: block;
+	margin-left: auto;
+	margin-right: auto:;
+	margin-top: 2em;
+	margin-bottom: 2em;
+}
+
+figcaption {
+	margin-left: 2em;
+	margin-right: 2em;
+}
+
+/* Author ja affiliation tulevat ensimmäisenä jokaisen artikkelin alkuun. Niiden ulkonäköä muokataan tässä. */
+.author,
+.affiliation {
+	font-weight: normal;
+	padding: 0;
+	margin: 0;
+}
+
+/* Siirretään affiliaatiota vähän lähemmäs nimeä määrittelemällä molemmille marginaaliksi ensin 0 ja sitten affiliaatiolle alamarginaali tässä */
+.affiliation {
+	margin-bottom: 1.5em;
+}
+

--- a/docs/_assets/malli.html
+++ b/docs/_assets/malli.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="fi-FI" xml:lang="fi-FI">
+<head>
+  <meta charset="utf-8" />
+<title>Tekstin otsikko</title>
+</head>
+<body>
+<h1 class="title">Tekstin otsikko</h1>
+<p class="type">Tekstin tyyppi</p>
+<!-- Kirjoittajien tiedot, toistetaan tarvittaessa useita kertoja -->
+<p class="author">Tekstin kirjoittaja</p>
+<p class="affiliation">Tekstin affiliaatio</p>
+<h2>Tiivistelmä</h2>
+<p class="abstract-fi">Suomenkielinen tiivistelmä.</p>
+<p class="keywords-fi">Suomenkieliset asiasanat</p>
+<h2>Abstract</h2>
+<p class="abstract-en">Englanninkielinen tiivistelmä.</p>
+<p class="keywords-en">Englanninkieliset asiasanat</p>
+<h2 id="johdanto">Johdanto</h2>
+<p>Johdannon ensimmäinen kappale.</p>
+<p>Johdannon toinen kappale.</p>
+<h2 id="seuraava-otsikko">Seuraava otsikko</h2>
+<p>Seuraavan otsikon alle tuleva teksti.</p>
+<figure>
+<img src="source/img/image-file.png" alt="Selittävä teksti niille, jotka eivät näe kuvaa. Voi olla esimerkiksi kuvateksti ja muuta selittävää tietoa." /><figcaption aria-hidden="true">Kuvateksti.</figcaption>
+</figure>
+<blockquote>
+<p>Pidempi sitaatti tulee blockquote-elementin sisään.</p>
+</blockquote>
+<h2 id="kiitokset">Kiitokset</h2>
+<p>Tämän mallin luomisen on mahdollistanut Suomen Akatemian rahoittama Pelikulttuurien tutkimuksen huippuyksikkö (rahoituspäätös 312440).</p>
+<h2 id="lähteet">Lähteet</h2>
+<!-- Esimerkki lähteestä. Jokainen tulee tekstin tapaan oman <p>-elementin sisään. -->
+<p>Saarikoski, Petri. 2012. “‘Rakas Pelit-lehden toimitus…’ <em>Pelit</em>-lehden lukijakirjeet ja digipelaamisen muutos Suomessa vuosina 1992–2002”. <em>Pelitutkimuksen vuosikirja 2012</em>, toimittaneet Jaakko Suominen, Raine Koskimaa, Frans Mäyrä, ja Riikka Turtiainen, 21–40. Tampere: Tampereen yliopisto. <a href="https://www.pelitutkimus.fi/vuosikirja2012/ptvk2012-04.pdf" class="uri">https://www.pelitutkimus.fi/vuosikirja2012/ptvk2012-04.pdf</a>.</p>
+<p>Saarikoski, Petri ja Jaakko Suominen. 2009b. “Pelinautintoja, ohjelmointiharrastusta ja liiketoimintaa”. <em>Pelitutkimuksen vuosikirja 2009</em>, toimittaneet Jaakko Suominen, Raine Koskimaa, Frans Mäyrä, ja Olli Sotamaa, 16–33. Tampereen yliopisto. <a href="https://www.pelitutkimus.fi/wp-content/uploads/2009/08/ptvk2009-02.pdf" class="uri">https://www.pelitutkimus.fi/wp-content/uploads/2009/08/ptvk2009-02.pdf</a>.</p>
+<p>Suominen, Jaakko. 2015. Suomen ensimmäinen konsolipelibuumi 1988-94 tietokonelehdistön ja pelaajien muistitiedon kautta tarkasteltuna. <em>Pelitutkimuksen vuosikirja 2015</em>, 72-98. Tampereen yliopisto. <a href="https://www.pelitutkimus.fi/vuosikirja2015/artikkeli-suomen-ensimmainen-konsolipelibuumi-1988-1994-tietokonelehdiston-ja-pelaajien-muistitiedon-kautta-tarkasteltuna" class="uri">https://www.pelitutkimus.fi/vuosikirja2015/artikkeli-suomen-ensimmainen-konsolipelibuumi-1988-1994-tietokonelehdiston-ja-pelaajien-muistitiedon-kautta-tarkasteltuna</a>.</p>
+</body>
+</html>

--- a/docs/journal-fi/css.md
+++ b/docs/journal-fi/css.md
@@ -1,0 +1,37 @@
+# HTML-muotoisten artikkelien asettelu Journal.fi-julkaisuissa
+
+Journal.fi:n käyttämä [Open Journal Systems](https://pkp.sfu.ca/ojs/) mahdollistaa HTML-muotoisten julkaisujen lisäämisen julkaisujen sivustoille. Käytännössä harva julkaisu kuitenkaan hyödyntää tätä mahdollisuutta. Käytännössä HTML-julkaisujen tukeminen vaati kolme asiaa:
+
+1. Oikean lisäosan käyttämisen,
+2. CSS-tyylitiedoston kirjoittamisen ja
+3. julkaisujen oikean muotoilun.
+
+## 1. Oikea lisäosa
+
+Journal.fissä on tarjolla kaksi eri HTML-lisäosaa. Toinen on TSV:n ylläpitämä ja toimii paremmin useimmissa tapauksissa. Molemmat löytyvät oman julkaisun ylläpitosivulta seuraavasta polusta:
+
+> Asetukset -- Verkkosivuston asetukset -- Lisäosat
+
+TSV:n ylläpitämä lisäosa on nimeltään
+
+> Vaihtoehtoinen HTML-artikkelin lisäosa
+
+Sen voi aktivoida laittamalla lisäosan kohdalla raksin ruutuun.
+
+## 2. CSS-tyylitiedosto
+
+HTML-lisäosa ottaa valmiin julkaisun tiedoston ja lataa sen verkkoselaimessa. Valitettavasti oletuksena siihen ei sisälly muotoiluja, joten lopputulos on yksi iso pötkö tekstiä. Jotta lopputulos on hieman luettavampi, järjestelmään täytyy ladata oma tyylitiedosto. Se onnistuu polusta:
+
+> Asetukset -- Verkkosivuston asetukset -- Lisäasetukset -- Julkaisun tyylitiedosto
+
+Tyylitiedosto täytyy olla valmiiksi kirjoitettu omaan CSS-tiedostoonsa ja se ladataan järjestelmään sellaisenaan.
+
+[Voit ladata tämän perusasettelun sisältävän CSS-tiedoston]({% site.baseurl %}/assets/StyleSheet.css) ja muokata sitä vastaamaan paremmin omia tarpeitasi tai ladata sen sellaisenaan järjestelmään.
+
+# 3. Julkaisujen oikea muotoilu
+
+Lisäosan ja tyylitiedoston lisäksi tarvitaan vielä julkaistavat tekstit oikeassa muodossa.
+
+Käytännössä kyseessä on hyvin yksinkertainen HTML-tiedosto, joka ladataan sellaisenaan Journal.fi-järjestelmään. Järjestelmä tekee siihen jotain muutoksia, kun se ladataan, joten lopputulos ei ihan vastaa alkuperäistä tiedostoa.
+
+[Voit ladata valmiin esimerkkitiedoston]({% site.baseurl %}/assets/malli.html) ja katsoa, että julkaistavissa teksteissä on tarvittavat osiot. Käytännössä lopulliset julkaistavat tiedostot luodaan taitto-ohjelmassa samaan tapaan kuin julkaistavat PDF-tiedostot.


### PR DESCRIPTION
Kirjoitin tämän ohjeen joskus 2022 ja silloin oli puhetta, että sitä saisi käyttää osana yleisiä ohjeita. En tiedä päätyikö se koskaan osaksi Google-dokumenteissa olleita ohjeita, mutta tässä olisi lisäys verkossa oleviin ohjeisiin.

Minulla ei ollut tarvittavia paketteja testata Github Pagesin kanssa yhteensopivaa jekyll-asennusta, joten en testannut tätä livenä. Siellä saattaa siis olla jotain virheitä, mutta aiempien ohjetekstien perusteella sivusto näytti aika perus-jekyll-mallilta.